### PR TITLE
Add tab to "Join" page to display previously joined session

### DIFF
--- a/app/components/SessionTile.jsx
+++ b/app/components/SessionTile.jsx
@@ -1,0 +1,59 @@
+import { PropTypes } from 'react';
+import { connect } from 'react-redux';
+import Component from '../Component';
+import style from './SessionTile.scss';
+import ClassNames from 'classnames';
+import translate from '../i18n/Translate';
+import { Card, CardTitle, CardActions } from 'react-toolbox/lib/card';
+import { default as Button } from 'react-toolbox/lib/button';
+
+const stateToProps = state => ({ });
+
+const actionsToProps = dispatch => ({});
+
+@translate('SessionTile')
+@translate('SessionName')
+@connect(stateToProps, actionsToProps)
+class SessionTile extends Component {
+    renderLastJoined (lastJoined) {
+        const MINUTE = 60 * 1000;
+        const HOUR = 60 * MINUTE;
+        const DAY = HOUR * 24;
+
+        let diff = Date.now() - lastJoined;
+        let days = Math.floor(diff / DAY);
+        let hours = Math.floor((diff - (days * DAY)) / HOUR);
+        let minutes = Math.floor((diff - (days * DAY) - (hours * HOUR))/ MINUTE);
+        return this.props.strings.lastJoined.replace('${days}', days).replace('${hours}', hours).replace('${minutes}', minutes)
+
+    }
+    render() {
+
+        return (
+            <div className={ClassNames('col-4-12', 'mobile-col-1-2', style.sessionTile)}>
+                <Card>
+                    <CardTitle title={ this.props.session.name || this.props.strings.defaultSessionName } subtitle={this.renderLastJoined(this.props.session.lastJoin)} />
+                    <CardActions>
+                        {this.props.children}
+                    </CardActions>
+                </Card>
+            </div>
+        )
+    }
+}
+
+SessionTile.propTypes = {
+    session: PropTypes.object.isRequired,
+    strings: PropTypes.object
+}
+
+SessionTile.defaultProps = {
+    session: null,
+    strings: {
+        defaultSessionName: 'My Retrospective',
+        lastJoined: '${days} day(s), ${hours} hours and ${minutes} minutes ago'
+    }
+
+}
+
+export default SessionTile;

--- a/app/components/SessionTile.scss
+++ b/app/components/SessionTile.scss
@@ -1,0 +1,3 @@
+div.sessionTile {
+  padding-bottom: 20px;
+}

--- a/app/i18n/en.js
+++ b/app/i18n/en.js
@@ -36,6 +36,10 @@ export default {
             header: 'Advanced',
             input: 'Enter a name for your session',
             button: 'Create custom session'
+        },
+        previousTab: {
+            header: 'Previous sessions',
+            rejoinButton: 'Rejoin'
         }
     },
     Login: {
@@ -47,5 +51,8 @@ export default {
     },
     SessionName: {
         defaultSessionName: 'My Retrospective'
+    },
+    SessionTile: {
+        lastJoined: '${days} day(s), ${hours} hour(s) and ${minutes} minute(s) ago'
     }
 }

--- a/app/i18n/fr.js
+++ b/app/i18n/fr.js
@@ -35,6 +35,10 @@ export default {
             header: 'Avancé',
             input: 'Donnez un nom à votre session',
             button: 'Créer une session personalisée'
+        },
+        previousTab: {
+            header: 'Previous sessions',
+            rejoinButton: 'Rejoin'
         }
     },
     Login: {
@@ -46,5 +50,8 @@ export default {
     },
     SessionName: {
         defaultSessionName: 'Ma Retrospective'
+    },
+    SessionTile: {
+        lastJoined: '${days} day(s), ${hours} hour(s) and ${minutes} minute(s) ago'
     }
 }

--- a/app/i18n/hu.js
+++ b/app/i18n/hu.js
@@ -35,6 +35,10 @@ export default {
             header: 'Haladó',
             input: 'Adj nevet az ülésnek',
             button: 'Ülés létrehozása'
+        },
+        previousTab: {
+            header: 'Previous sessions',
+            rejoinButton: 'Rejoin'
         }
     },
     Login: {
@@ -46,5 +50,8 @@ export default {
     },
     SessionName: {
         defaultSessionName: 'My Retrospective'
+    },
+    SessionTile: {
+        lastJoined: '${days} day(s), ${hours} hour(s) and ${minutes} minute(s) ago'
     }
 }

--- a/app/i18n/nl.js
+++ b/app/i18n/nl.js
@@ -35,6 +35,10 @@ export default {
             header: 'Geavanceerd',
             input: 'Geef een naam voor de sessie',
             button: 'Maak een aangepaste sessie'
+        },
+        previousTab: {
+            header: 'Vorige sessies',
+            rejoinButton: 'Opnieuw deelnemen'
         }
     },
     Login: {
@@ -46,5 +50,8 @@ export default {
     },
     SessionName: {
         defaultSessionName: 'Mijn Retrospective'
+    },
+    SessionTile: {
+        lastJoined: '${days} dag(en), ${hours} uur en ${minutes} minuten geleden'
     }
 }

--- a/app/i18n/pt-br.js
+++ b/app/i18n/pt-br.js
@@ -35,6 +35,10 @@ export default {
             header: 'Avançado',
             input: 'Insira um nome para sua seção',
             button: 'Crie uma seção customizada'
+        },
+        previousTab: {
+            header: 'Previous sessions',
+            rejoinButton: 'Rejoin'
         }
     },
     Login: {
@@ -46,5 +50,8 @@ export default {
     },
     SessionName: {
         defaultSessionName: 'My Retrospective'
+    },
+    SessionTile: {
+        lastJoined: '${days} day(s), ${hours} hour(s) and ${minutes} minute(s) ago'
     }
 }

--- a/app/pages/Join.jsx
+++ b/app/pages/Join.jsx
@@ -10,8 +10,14 @@ import { Card, CardMedia, CardTitle, CardText, CardActions } from 'react-toolbox
 import { Tab, Tabs } from 'react-toolbox';
 import icons from '../constants/icons';
 import backgroundImage from '../components/images/background.jpg';
+import { getSavedSessions, getCurrentUser } from '../selectors';
+import SessionTile from '../components/SessionTile'
+import { push } from 'react-router-redux';
+import { browserHistory } from 'react-router'
 
-const stateToProps = state => ({ });
+const stateToProps = state => ({
+    previousSessions: getSavedSessions(getCurrentUser(state))
+});
 
 const actionsToProps = dispatch => ({
     createSession: () => dispatch(createSession()),
@@ -45,6 +51,13 @@ class Join extends Component {
                             <br />
                             <Button label={ strings.advancedTab.button } disabled={!this.state.customSessionName} accent raised onClick={() => this.props.createCustomSession(this.state.customSessionName)} />
                         </Tab>
+                        <Tab label={ strings.previousTab.header }>
+                            { this.props.previousSessions.map((session, index) =>
+                                <SessionTile key={session.id} session = {session}>
+                                    <Button label={ strings.previousTab.rejoinButton } accent raised onClick={() => browserHistory.push('/session/'+session.id)}/>
+                                </SessionTile>
+                            )}
+                        </Tab>
                     </Tabs>
 
                 </CardText>
@@ -55,12 +68,14 @@ class Join extends Component {
 }
 
 Join.propTypes = {
+    previousSessions: PropTypes.array,
     createSession: PropTypes.func,
     createCustomSession: PropTypes.func,
     strings: PropTypes.object
 };
 
 Join.defaultProps = {
+    previousSessions: [],
     createSession: noop,
     createCustomSession: noop,
     strings: {
@@ -74,6 +89,10 @@ Join.defaultProps = {
             header: 'Advanced',
             input: 'Enter a name for your session',
             button: 'Create custom session'
+        },
+        previousTab: {
+            header: 'Previous sessions',
+            rejoinButton: 'Rejoin'
         }
     }
 }

--- a/app/sagas/index.js
+++ b/app/sagas/index.js
@@ -1,16 +1,18 @@
 import { takeEvery, takeLatest } from 'redux-saga'
 import { AUTO_LOGIN, LOGIN, LOGOUT, CHANGE_LANGUAGE } from '../state/user';
-import { AUTO_JOIN, LEAVE_SESSION, CREATE_SESSION } from '../state/session';
+import { AUTO_JOIN, LEAVE_SESSION, CREATE_SESSION, RECEIVE_SESSION_NAME, RENAME_SESSION } from '../state/session';
 import { ADD_POST, LIKE } from '../state/posts';
 import { INITIALISE } from '../state/actions';
 
 import { storeUserToLocalStorage, deleteUserFromLocalStorage, storeLanguageToLocalStorage, loginSuccess, changeLanguageSuccess, disconnectUser, autoLoginUser } from './user';
 import { addPost, like } from './posts';
-import { autoJoinUser, createSession } from './session';
+import { autoJoinUser, createSession, renameCurrentSessionInLocalStorage } from './session';
 
 const watchers = [
     function* () { yield* takeEvery(AUTO_LOGIN, autoLoginUser); },
     function* () { yield* takeEvery(AUTO_JOIN, autoJoinUser); },
+    function* () { yield* takeEvery(RECEIVE_SESSION_NAME, renameCurrentSessionInLocalStorage); },
+    function* () { yield* takeEvery(RENAME_SESSION, renameCurrentSessionInLocalStorage); },
     function* () { yield* takeEvery(LOGIN, storeUserToLocalStorage); },
     function* () { yield* takeEvery(LOGOUT, deleteUserFromLocalStorage); },
     function* () { yield* takeEvery(CHANGE_LANGUAGE, storeLanguageToLocalStorage); },

--- a/app/selectors/index.js
+++ b/app/selectors/index.js
@@ -1,5 +1,6 @@
 import { createSelector } from 'reselect';
 import sortBy from 'lodash/sortBy';
+import ls from 'local-storage';
 
 // Utility functions
 const sortByVotes = posts => sortBy(posts, p => -(p.likes.length - p.dislikes.length));
@@ -12,6 +13,14 @@ export const getCurrentUser = state => state.user.name;
 export const getCurrentLanguage = state => state.user.lang;
 export const getClients = state => state.session.clients;
 export const getSessionName = state => state.session.name;
+
+export const getSavedSessions = function (currentUser) {
+    let sessions = ls.get('sessions');
+    if (!!sessions && sessions.hasOwnProperty(currentUser)) {
+        return sessions[currentUser];
+    }
+    return [];
+};
 
 // Selector Factories
 const getPostsOfType = type => createSelector(getPosts, posts => posts.filter(p => p.postType === type));


### PR DESCRIPTION
This feature saves the joined session in local storage on a user basis and give the opportunity to join them again without the need to remember the url.

Seeing as I don't really know ReactJS all that good, I don't really know if I did everything good.
Also don't feel obligated to add this to your project, but I thought it might be a nice addition.