### PR TITLE
linebreak-style eslint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,8 @@
       "no-param-reassign": 0,
       "comma-dangle": ["error", "never"],
       "arrow-parens": 0,
-      "react/forbid-prop-types": 0
+      "react/forbid-prop-types": 0,
+      "linebreak-style": 0
   },
   "parserOptions": {
         "ecmaFeatures": {

--- a/samplefile.txt
+++ b/samplefile.txt
@@ -1,1 +1,0 @@
-File to check if I forked and working correctly

--- a/samplefile.txt
+++ b/samplefile.txt
@@ -1,0 +1,1 @@
+File to check if I forked and working correctly


### PR DESCRIPTION
Hi, 
I'm new to open source contribution on GitHub. I've forked your project and started to go through the project. Set up the server and ran the npm start commands to get the project up and running in my local. But the webpack compilation failed because of linebreak styling in windows machine. I had to add a rule in eslintrc file to ignore the linebreak-style across the operating systems. I thought every windows user must be facing this problem. So added the rule. Is it fine if this is merged in master. Will benefit other users as well. 
My apologies if i've created a pull request in a wrong manner. 