### PR TITLE
Use pre-wrap instead of pre to wrap long lines

### DIFF
--- a/retro-board-app/src/components/EditableLabel.tsx
+++ b/retro-board-app/src/components/EditableLabel.tsx
@@ -122,7 +122,7 @@ const LabelContainer = styled.span``;
 const ViewMode = styled.span`
   display: inline-block;
   > span {
-    white-space: pre;
+    white-space: pre-wrap;
     line-height: 1.5;
   }
 `;


### PR DESCRIPTION
## Overview

I found a long line caused the layout broken.
When a long line enough to cover a whole screen, the rest columns becomes too small, hard to be selected.

## Solution

I fixed the problem by using `white-space: pre-wrap;` instead of `white-space: pre;`.

## Screenshots

|before|after|
|---|---|
|![before](https://user-images.githubusercontent.com/1672393/68602872-81842180-04ea-11ea-97e2-49e186057106.png)|![after](https://user-images.githubusercontent.com/1672393/68602815-62858f80-04ea-11ea-897a-ab1b948b478e.png)|