### PR TITLE
fix: login error when github account does not have display name

### DIFF
--- a/retro-board-server/src/auth/passport.ts
+++ b/retro-board-server/src/auth/passport.ts
@@ -27,6 +27,10 @@ export default (store: Store) => {
     profile: any,
     cb: Function
   ) => {
+    if (profile.displayName.length == 0) {
+        profile.displayName = profile.username ||
+            (profile.emails.length ? profile.emails[0].value : null);
+    }
     const user: User = {
       accountType: type,
       id: v4(),

--- a/retro-board-server/src/auth/passport.ts
+++ b/retro-board-server/src/auth/passport.ts
@@ -27,7 +27,7 @@ export default (store: Store) => {
     profile: any,
     cb: Function
   ) => {
-    if (profile.displayName.length == 0) {
+    if (profile.displayName == null) {
         profile.displayName = profile.username ||
             (profile.emails.length ? profile.emails[0].value : null);
     }

--- a/retro-board-server/src/auth/passport.ts
+++ b/retro-board-server/src/auth/passport.ts
@@ -29,7 +29,7 @@ export default (store: Store) => {
   ) => {
     if (profile.displayName == null) {
         profile.displayName = profile.username ||
-            (profile.emails.length ? profile.emails[0].value : null);
+            (profile.emails.length ? profile.emails[0].value : '');
     }
     const user: User = {
       accountType: type,


### PR DESCRIPTION
When using Github account without name to log in the application. Server thows an error like this. I fixed this issue by check if that account has name or not then set default name.


![error-github-without-name](https://user-images.githubusercontent.com/43868345/98500096-12b4e200-227e-11eb-8795-b6ad164d19d0.jpg)

**Account can log in:**
![true-profile](https://user-images.githubusercontent.com/43868345/98500340-d930a680-227e-11eb-8e14-423fec6a6656.png)

**Account can NOT login:**
![false-profile](https://user-images.githubusercontent.com/43868345/98500351-ddf55a80-227e-11eb-9ecf-3bf41d8cb6e3.png)


