### PR TITLE
Adjust Panel layout

### DIFF
--- a/frontend/src/views/Panel.tsx
+++ b/frontend/src/views/Panel.tsx
@@ -107,7 +107,6 @@ const Policies = styled.div`
   border-top: 1px solid grey;
   display: flex;
   flex-direction: column;
-  margin: -10px;
   padding: 20px 30px 30px 30px;
 
   a {


### PR DESCRIPTION
Remove unnecessary CSS property that was causing a horizontal scroll in the side panel

| Before  | After  |
|---|---|
| <img src="https://github.com/antoinejaussoin/retro-board/assets/13110218/93c57885-f005-4fac-82cc-a6efc0b250cd" height="500">  | <img src="https://github.com/antoinejaussoin/retro-board/assets/13110218/0d7f6630-38f3-4905-86ca-116208657fca" height="500">  |


